### PR TITLE
FFS-2035: continue from previous offset on assignment for instance-deleted consumer

### DIFF
--- a/src/main/kotlin/no/novari/flyt/files/infrastructure/kafka/InstanceDeletedConsumerConfiguration.kt
+++ b/src/main/kotlin/no/novari/flyt/files/infrastructure/kafka/InstanceDeletedConsumerConfiguration.kt
@@ -65,7 +65,7 @@ class InstanceDeletedConsumerConfiguration(
                     .groupIdApplicationDefault()
                     .maxPollRecordsKafkaDefault()
                     .maxPollIntervalKafkaDefault()
-                    .seekToBeginningOnAssignment()
+                    .continueFromPreviousOffsetOnAssignment()
                     .build(),
                 errorHandlerFactory.createErrorHandler(
                     ErrorHandlerConfiguration


### PR DESCRIPTION
## Summary
- Bytter `seekToBeginningOnAssignment()` til `continueFromPreviousOffsetOnAssignment()` i `InstanceDeletedConsumerConfiguration` siden seek-to-beginning er unødvendig her.

Jira: FFS-2035