### PR TITLE
FFS-2183: Oppgrader file-service til web-resource-server 4.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     implementation("com.azure:azure-storage-blob:12.35.0")
 
     implementation("no.novari:flyt-cache:3.0.0")
-    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-1")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-2")
     implementation("no.novari:flyt-kafka:7.2.0")
 
     implementation("org.apache.commons:commons-text:1.15.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     implementation("com.azure:azure-storage-blob:12.35.0")
 
     implementation("no.novari:flyt-cache:3.0.0")
-    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-2")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-3")
     implementation("no.novari:flyt-kafka:7.2.0")
 
     implementation("org.apache.commons:commons-text:1.15.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     implementation("com.azure:azure-storage-blob:12.35.0")
 
     implementation("no.novari:flyt-cache:3.0.0")
-    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-3")
+    implementation("no.novari:flyt-web-resource-server:4.0.0")
     implementation("no.novari:flyt-kafka:7.2.0")
 
     implementation("org.apache.commons:commons-text:1.15.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,8 @@ dependencies {
     implementation("com.google.guava:guava:33.6.0-jre")
     implementation("com.azure:azure-storage-blob:12.35.0")
 
-    implementation("no.novari:flyt-web-resource-server:3.2.0")
+    implementation("no.novari:flyt-cache:3.0.0")
+    implementation("no.novari:flyt-web-resource-server:4.0.0-rc-1")
     implementation("no.novari:flyt-kafka:7.2.0")
 
     implementation("org.apache.commons:commons-text:1.15.0")


### PR DESCRIPTION
## Summary

Implements [FFS-2183](https://novari-iks.atlassian.net/browse/FFS-2183).

- Oppgraderer til `flyt-web-resource-server:4.0.0`.
- Beholder eksisterende roller og interne API-er.

[FFS-2183]: https://novari-iks.atlassian.net/browse/FFS-2183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ