### PR TITLE
FFS-2224 Aktiver sporing og JSON-logging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     compileOnly("org.springframework.security:spring-security-web")
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("io.github.oshai:kotlin-logging-jvm:7.0.3")
+    implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.google.guava:guava:33.6.0-jre")
     implementation("com.azure:azure-storage-blob:12.35.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,8 +40,9 @@ dependencies {
     implementation("com.azure:azure-storage-blob:12.35.0")
 
     implementation("no.novari:flyt-cache:3.0.0")
-    implementation("no.novari:flyt-web-resource-server:4.0.0")
-    implementation("no.novari:flyt-kafka:7.2.0")
+    implementation("no.novari:flyt-web-resource-server:4.1.0-rc-2")
+    implementation("no.novari:flyt-kafka:7.3.0-rc-2")
+    implementation("no.novari:telemetry-starter:0.0.3")
 
     implementation("org.apache.commons:commons-text:1.15.0")
     implementation("org.apache.commons:commons-lang3:3.20.0")

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "afk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "agderfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "bfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "ffk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "fintlabs-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "innlandetfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "ofk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "rogfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "telemarkfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "tromsfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "trondelagfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "vestfoldfylke-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "vlfk-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -23,7 +23,7 @@ patches:
         path: "/spec/env/-"
         value:
          name: "novari.kafka.topic.orgId"
-         value: "$FINT_KAFKA_TOPIC_ORGID"
+         value: "$FINT_KAFKA_TOPIC_ORGID"$OTEL_ENV_PATCH
     target:
       kind: Application
       name: fint-flyt-file-service

--- a/script/render-overlay.sh
+++ b/script/render-overlay.sh
@@ -5,6 +5,21 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TEMPLATE_DIR="$ROOT/kustomize/templates"
 BASE_TEMPLATE="$TEMPLATE_DIR/overlay.yaml.tpl"
 
+OTEL_ENDPOINT_BETA="http://alloy.flais-system.svc.cluster.local:4318"
+
+# Base-URL uten /v1/traces: telemetry-starter legger på signal-stien selv.
+# Settes manuelt inntil flaiserator har støtte for det, og kun i beta der Alloy kjører.
+build_otel_env_patch() {
+  local environment="$1"
+
+  if [[ "$environment" != "beta" ]]; then
+    return
+  fi
+
+  printf '\n      - op: add\n        path: "/spec/env/-"\n        value:\n          name: "OTEL_EXPORTER_OTLP_ENDPOINT"\n          value: "%s"' \
+    "$OTEL_ENDPOINT_BETA"
+}
+
 while IFS= read -r file; do
   rel="${file#"$ROOT/kustomize/overlays/"}"
   dir="$(dirname "$rel")"
@@ -21,6 +36,7 @@ while IFS= read -r file; do
   export KAFKA_TOPIC="${namespace}.flyt.*"
   export BLOB_INSTANCE="fint-flyt-file-service-azure-blob-storage_${namespace//-/_}"
   export FINT_KAFKA_TOPIC_ORGID="$namespace"
+  export OTEL_ENV_PATCH="$(build_otel_env_patch "$env_path")"
 
   target_dir="$ROOT/kustomize/overlays/$dir"
   template="$BASE_TEMPLATE"

--- a/src/main/resources/application-flyt-kafka.yaml
+++ b/src/main/resources/application-flyt-kafka.yaml
@@ -3,6 +3,8 @@ novari:
     topic:
       domain-context: flyt
     application-id: ${fint.application-id}
+    tracing:
+      enabled: true
 
 spring:
   kafka:

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,22 +1,8 @@
 <configuration scan="true">
 
-    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-            <providers>
-                <timestamp/>
-                <logLevel/>
-                <threadName/>
-                <loggerName/>
-                <message/>
-                <arguments/>
-                <throwableClassName/>
-                <throwableMessage/>
-                <stackTrace useShortFormat="true"/>
-            </providers>
-        </encoder>
-    </appender>
+    <include resource="no/novari/telemetry/logback-json.xml"/>
 
     <root level="INFO">
-        <appender-ref ref="JSON"/>
+        <appender-ref ref="TELEMETRY_JSON"/>
     </root>
 </configuration>


### PR DESCRIPTION
## Sammendrag

- Legger til `telemetry-starter` for HTTP-selvinstrumentering
- Bumper `flyt-kafka` og `flyt-web-resource-server` til versjoner med Kafka-sporing (`novari.kafka.tracing.enabled=true`) og korrekt trace-propagering
- Kobler inn telemetry-starter sitt JSON-loggfragment i den allerede aktive strukturerte loggingen, slik at `traceId`/`spanId` blir søkbare
- Bumper `kotlin-logging-jvm` til `8.0.4` for konsistens med de andre repoene i utrullingen (egen commit)

Del av OpenTelemetry-tracing-epicen (FFS-2196), jf. rettet beslutning 13 i løsningsanalysen (Kafka-sporing skal på i alle utrullinger, ikke bare instance-service).